### PR TITLE
Append page name to hypothes.is via links

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -27,7 +27,7 @@
 
     <!-- The code below is used for manually entered links  -->
 
-    <a class="sidebar-nav-item" href="https://via.hypothes.is/{{ site.url }}{{ site.baseurl }}/">Annotate me</a>
+    <a class="sidebar-nav-item" href="https://via.hypothes.is/{{ site.url }}{{ site.baseurl }}{{ page.url }}">Annotate me</a>
     <a class="sidebar-nav-item" href="https://github.com/elotroalex/ed" target="_blank">GitHub project</a>
     <span class="sidebar-nav-item">Currently v{{ site.version }}</span>
   </nav>


### PR DESCRIPTION
At present the "Annotate this" link is not truly descriptive since the URL to which it points will redirect the user back to the homepage. By append page.name as a liquid variable to the end of the URL the page will reload to the current edition.

However, even with this PR the user will still lose his or her place in the current text, so annotation becomes disruptive. You could consider replacing the via hypothesis method with an inline javascript method:

`javascript:(function(){var%20d=document,s=d.createElement('script');s.setAttribute('src','https://hypothes.is/app/embed.js');d.body.appendChild(s);setTimeout(function(){$('[name=\&quot;sidebar-toggle&quot;]').click();}, 1500);})();` 

since this is what the hypothesis code does anyway.
