### PR TITLE
Added highlighting to search feature

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,11 +36,11 @@
       var url = window.location.href;
       if (url.lastIndexOf("?q=") > 0) {
         // get the index of the parameter, add three (to account for length)
-        var index = url.lastIndexOf("?q=") + 3;
+        var searchloc = url.lastIndexOf("?q=") + 3;
         // get the substring (query) and decode
-        var search = decodeURIComponent(url.substr(index));
+        var searchquery = decodeURIComponent(url.substr(searchloc));
         // regex matches at begnning of line, end of line or word boundary, useful for poetry
-        var regex = new RegExp("(?:^|\\b)(" + search + ")(?:$|\\b)", "gim");
+        var regex = new RegExp("(?:^|\\b)(" + searchquery + ")(?:$|\\b)", "gim");
         // get, add mark and then set content
         var content = document.getElementById("main").innerHTML;
         document.getElementById("main").innerHTML = content.replace(regex, "<mark>$1</mark>");

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,10 +36,11 @@
       var url = window.location.href;
       if (url.lastIndexOf("?q=") > 0) {
         // get the index of the parameter, add three (to account for length)
-        var index = url.lastIndexOf("?q=") + 3);
+        var index = url.lastIndexOf("?q=") + 3;
         // get the substring (query) and decode
         var search = decodeURIComponent(url.substr(index));
-        var regex = new RegExp("\\b(" + search + ")\\b", "gim"); //regex to search whole words only
+        // regex matches at begnning of line, end of line or word boundary, useful for poetry
+        var regex = new RegExp("(?:^|\\b)(" + search + ")(?:$|\\b)", "gim");
         // get, add mark and then set content
         var content = document.getElementById("main").innerHTML;
         document.getElementById("main").innerHTML = content.replace(regex, "<mark>$1</mark>");

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,8 +35,12 @@
     <script>
       var url = window.location.href;
       if (url.lastIndexOf("?q=") > 0) {
-        var search = url.substr(url.lastIndexOf("?q=") + 3);
-        var regex = new RegExp("\\b(" + search + ")\\b", "gim");
+        // get the index of the parameter, add three (to account for length)
+        var index = url.lastIndexOf("?q=") + 3);
+        // get the substring (query) and decode
+        var search = decodeURIComponent(url.substr(index));
+        var regex = new RegExp("\\b(" + search + ")\\b", "gim"); //regex to search whole words only
+        // get, add mark and then set content
         var content = document.getElementById("main").innerHTML;
         document.getElementById("main").innerHTML = content.replace(regex, "<mark>$1</mark>");
       }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
         </div>
       </div>
 
-      <div class="container content">
+      <div class="container content" id="main">
         {{ content }}
       </div>
     </div>
@@ -33,6 +33,13 @@
     <label for="sidebar-checkbox" class="sidebar-toggle"></label>
 
     <script>
+      var url = window.location.href;
+      if (url.lastIndexOf("?q=") > 0) {
+        var search = url.substr(url.lastIndexOf("?q=") + 3);
+        var regex = new RegExp("\\b(" + search + ")\\b", "gim");
+        var content = document.getElementById("main").innerHTML;
+        document.getElementById("main").innerHTML = content.replace(regex, "<mark>$1</mark>");
+      }
       (function(document) {
         var toggle = document.querySelector('.sidebar-toggle');
         var sidebar = document.querySelector('#sidebar');

--- a/public/css/ed.css
+++ b/public/css/ed.css
@@ -1,10 +1,10 @@
 /* Ed: the minimal edition theme.
- * ___________________   
- * \_   _____/\______ \  
- *  |    __)_  |    |  \ 
+ * ___________________
+ * \_   _____/\______ \
+ *  |    __)_  |    |  \
  *  |        \ |    `   \
  * /_______  //_______  /
- *         \/         \/ 
+ *         \/         \/
  * Designed, built, and released under an MIT license by @elotroalex.
  * Based on the Poole and Lanyon theme by @mdo. Learn more at
  * https://github.com/elotroalex/ed.
@@ -113,7 +113,7 @@ a:focus {
 h1, h2, h3, h4, h5, h6 {
   font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
   margin-bottom: .5rem;
-  font-weight: 400; 
+  font-weight: 400;
   font-size: 1.5rem;
   color: #404040;
   letter-spacing: -.025rem;
@@ -196,12 +196,15 @@ abbr[title] {
   cursor: help;
   border-bottom: 1px dotted #e5e5e5;
 }
+mark {
+  color: inherit;
+}
 
 /* Quotes */
 
 blockquote {
 	padding: 0rem 1.5rem 0rem 2rem;
-	margin: 0 0 20px 0; 
+	margin: 0 0 20px 0;
   	color: #454545;
 	border-left: none;
 	font-style: italic;
@@ -800,6 +803,3 @@ ol.bibliography {
 	padding-left: 1rem;
 	text-indent: -1rem;
 }
-
-
-

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -37,13 +37,16 @@ var store = [{% for text in site.texts %}{
 }
 {% unless forloop.last %},{% endunless %}{% endfor %}]
 
-//Query 
+//Query
 
 $(document).ready(function() {
+  $('form#site_search').on('submit', function(e) {
+    e.preventDefault();
+  });
   $('input#search').on('keyup', function () {
 	var resultdiv = $('#results');
 	var query = $(this).val();
- 
+
   //The search is then launched on the index built with Lunr
   var result = index.search(query);
   resultdiv.empty();
@@ -51,7 +54,7 @@ $(document).ready(function() {
   //Loop through, match, and add results
   for (var item in result) {
 	var ref = result[item].ref;
-    var searchitem = '<div class="result"><p><a href="{{ site.baseurl }}'+store[ref].link+'">'+store[ref].title+'</a> by '+store[ref].author+'</p></div>';
+    var searchitem = '<div class="result"><p><a href="{{ site.baseurl }}'+store[ref].link+'?q=' + query + '">'+store[ref].title+'</a> by '+store[ref].author+'</p></div>';
     resultdiv.append(searchitem);
    }
   });


### PR DESCRIPTION
1. The container div for the content now has id `main` to simplify the JavaScript. 
2. The search page now appends GET parameter `q` to each result link to allow for highlighting. 
3. The search form no longer submits upon hitting enter to prevent the user from accidentally losing their query and results. 
4. A small JavaScript script gets the parameter `q`, processes the result, and adds the tag `<mark>` around any matches. 
5. `color` property on `mark` was set to `inherit` to match the rest of Ed's theme (defaults to black). 

As of right now the script will not highlight a term that is split by a footnote (e.g. searching "bugle trills" will return "O Captain! My Captain!" but will not be highlighted), but will work _within_ footnotes. Now with fixed variables it will work more reliably (and highlight the static text on the search page without breaking functionality, if you want). 
