### PR TITLE
 Updated Emily Dickinson example to Kramdown syntax.

### DIFF
--- a/_texts/delayed.md
+++ b/_texts/delayed.md
@@ -27,7 +27,7 @@ source: Bartleby.com
 
 - Oh, if there may departing be	
 - Any forgot by victory	
-- {:.indent-2}In her imperial round,  
+- {:.indent-2}In her imperial round,
 - Show them this meek apparelled thing,	
 - That could not stop to be a king,	
 - {:.indent-2}Doubtful if it be crowned!

--- a/_texts/delayed.md
+++ b/_texts/delayed.md
@@ -7,6 +7,8 @@ source: Bartleby.com
 
 <p class="citation"> by {{ page.author }}</p>
 
+<br>
+
 - DELAYED till she had ceased to know,	
 - Delayed till in its vest of snow	
 - {:.indent-2}Her loving bosom lay.	

--- a/_texts/delayed.md
+++ b/_texts/delayed.md
@@ -7,27 +7,25 @@ source: Bartleby.com
 
 <p class="citation"> by {{ page.author }}</p>
 
-<br>
-
 - DELAYED till she had ceased to know,	
 - Delayed till in its vest of snow	
-- <span class="indent-2">Her loving bosom lay.</span>	
+- {:.indent-2}Her loving bosom lay.	
 - An hour behind the fleeting breath,	
 - Later by just an hour than death,—
-- <span class="indent-2">Oh, lagging yesterday!</span>	
+- {:.indent-2}Oh, lagging yesterday!	
 
 
 - Could she have guessed that it would be;	
 - Could but a crier of the glee	
-- <span class="indent-2">Have climbed the distant hill;</span>
+- {:.indent-2}Have climbed the distant hill;
 - Had not the bliss so slow a pace,—
 - Who knows but this surrendered face	
-- <span class="indent-2">Were undefeated still?<span>
+- {:.indent-2}Were undefeated still?
 
 
 - Oh, if there may departing be	
 - Any forgot by victory	
-- <span class="indent-2">In her imperial round,</span>
+- {:.indent-2}In her imperial round,  
 - Show them this meek apparelled thing,	
 - That could not stop to be a king,	
-- <span class="indent-2">Doubtful if it be crowned!</span>
+- {:.indent-2}Doubtful if it be crowned!


### PR DESCRIPTION
The Emily Dickinson example was using HTML instead of the Kramdown syntax discussed in the documentation. Updated for consistency.
